### PR TITLE
Node43 support

### DIFF
--- a/lib/RuntimeWebpack.js
+++ b/lib/RuntimeWebpack.js
@@ -24,7 +24,7 @@ module.exports = function(S) {
 
     getName(providerName) {
       if (providerName === 'aws') {
-        return 'nodejs';
+        return 'nodejs4.3'
       } else {
         return RuntimeWebpack.getName();
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ErikMikkelson/serverless-runtime-webpack.git"
+    "url": "git+https://github.com/elastic-coders/serverless-runtime-webpack.git"
   },
   "keywords": [
     "serverless",
@@ -20,9 +20,9 @@
   "author": "Nicola Peduzzi <elastic-coders.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ErikMikkelson/serverless-runtime-webpack/issues"
+    "url": "https://github.com/elastic-coders/serverless-runtime-webpack/issues"
   },
-  "homepage": "https://github.com/ErikMikkelson/serverless-runtime-webpack#readme",
+  "homepage": "https://github.com/elastic-coders/serverless-runtime-webpack#readme",
   "dependencies": {
     "bluebird": "^3.3.4",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-runtime-webpack",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Webpack runtime for the Serverless framework",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elastic-coders/serverless-runtime-webpack.git"
+    "url": "git+https://github.com/ErikMikkelson/serverless-runtime-webpack.git"
   },
   "keywords": [
     "serverless",
@@ -20,9 +20,9 @@
   "author": "Nicola Peduzzi <elastic-coders.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/elastic-coders/serverless-runtime-webpack/issues"
+    "url": "https://github.com/ErikMikkelson/serverless-runtime-webpack/issues"
   },
-  "homepage": "https://github.com/elastic-coders/serverless-runtime-webpack#readme",
+  "homepage": "https://github.com/ErikMikkelson/serverless-runtime-webpack#readme",
   "dependencies": {
     "bluebird": "^3.3.4",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Switch nodejs version to 4.3 (like serverless-runtime-babel did) and bump the version,  See https://github.com/serverless/serverless-runtime-babel/commit/79c87b25f47122440fa0250e81837ba82e4cd533
