### PR TITLE
Fixed fs.copy dependency

### DIFF
--- a/lib/RuntimeWebpack.js
+++ b/lib/RuntimeWebpack.js
@@ -10,7 +10,7 @@ module.exports = function(S) {
     chalk      = require('chalk'),
     spawnSync  = require('child_process').spawnSync,
     path       = require('path'),
-    fs         = BbPromise.promisifyAll(require('fs'));
+    fs         = BbPromise.promisifyAll(require('fs-extra'));
 
   class RuntimeWebpack extends S.classes.Runtime {
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "chalk": "^1.1.3",
+    "fs-extra": "^0.30.0",
     "glob": "^7.0.3",
     "lodash": "^4.8.2",
     "ramda": "^0.20.1",


### PR DESCRIPTION
It seems like you meant to include fs-extra instead of fs since you use fs.copy in the RuntimeWebpack since fs.copy is not available in the builtin nodejs filesystem package.

It might be related to #5

Thanks
